### PR TITLE
Improve literal datatype support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,5 @@ matrix:
 cache:
   directories:
     - $HOME/.m2
+
+script: mvn verify

--- a/pom.xml
+++ b/pom.xml
@@ -302,6 +302,18 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.0.0-M5</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,9 @@
             <exclude>README.md</exclude>
             <exclude>README.md.BAK</exclude>
             <exclude>LICENSE</exclude>
+
+            <!-- Ignore inconsistent (Apache) license for step mock helper class from Pentatho source https://github.com/pentaho/pentaho-kettle/blob/master/engine/src/test/java/org/pentaho/di/trans/steps/mock/StepMockHelper.java -->
+            <exclude>src/test/java/org/pentaho/di/trans/steps/mock/StepMockHelper.java</exclude>
           </excludes>
           <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -303,6 +303,7 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>3.0.0-M5</version>
         <executions>

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/jena/model/JenaModelStep.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/jena/model/JenaModelStep.java
@@ -297,7 +297,7 @@ public class JenaModelStep extends BaseStep implements StepInterface {
                         // typed literal
                         final String typeURI = mapping.rdfType.getNamespaceURI() + mapping.rdfType.getLocalPart();
                         final RDFDatatype rdfDatatype = TypeMapper.getInstance().getSafeTypeByName(typeURI);
-                        final String rdfLiteralValue = (String) convertSqlValueToRdf(fieldValue, rdfDatatype);
+                        final Object rdfLiteralValue = convertSqlValueToRdf(fieldValue, rdfDatatype);
                         final Literal literal = model.createTypedLiteral(rdfLiteralValue, rdfDatatype);
                         resource.addLiteral(property, literal);
                     }
@@ -347,7 +347,7 @@ public class JenaModelStep extends BaseStep implements StepInterface {
         }
 
         // fallback
-        logBasic("convertSqlValueToRdfLiteralValue: required {0} but was given: {1}, unsure how to convert... Will default to Object#toString()!", rdfDatatype.getURI(), sqlValue.getClass());
+        logBasic("convertSqlValueToRdfLiteralValue: required {0} but was given: {1}, unsure how to convert... Will default to {1}}!", rdfDatatype.getURI(), sqlValue.getClass());
         return sqlValue;
     }
 

--- a/src/test/java/org/pentaho/di/trans/steps/mock/StepMockHelper.java
+++ b/src/test/java/org/pentaho/di/trans/steps/mock/StepMockHelper.java
@@ -1,0 +1,157 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.steps.mock;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.pentaho.di.core.RowSet;
+import org.pentaho.di.core.logging.KettleLogStore;
+import org.pentaho.di.core.logging.LogChannel;
+import org.pentaho.di.core.logging.LogChannelInterface;
+import org.pentaho.di.core.logging.LogChannelInterfaceFactory;
+import org.pentaho.di.core.logging.LogLevel;
+import org.pentaho.di.core.logging.LogMessageInterface;
+import org.pentaho.di.core.logging.LoggingObjectInterface;
+import org.pentaho.di.trans.Trans;
+import org.pentaho.di.trans.TransMeta;
+import org.pentaho.di.trans.step.StepDataInterface;
+import org.pentaho.di.trans.step.StepMeta;
+import org.pentaho.di.trans.step.StepMetaInterface;
+
+public class StepMockHelper<Meta extends StepMetaInterface, Data extends StepDataInterface> {
+    public final StepMeta stepMeta;
+    public final Data stepDataInterface;
+    public final TransMeta transMeta;
+    public final Trans trans;
+    public final Meta initStepMetaInterface;
+    public final Data initStepDataInterface;
+    public final Meta processRowsStepMetaInterface;
+    public final Data processRowsStepDataInterface;
+    public final LogChannelInterface logChannelInterface;
+    public final LogChannelInterfaceFactory logChannelInterfaceFactory;
+    public final LogChannelInterfaceFactory originalLogChannelInterfaceFactory;
+
+    public StepMockHelper( String stepName, Class<Meta> stepMetaClass, Class<Data> stepDataClass ) {
+        originalLogChannelInterfaceFactory = KettleLogStore.getLogChannelInterfaceFactory();
+        logChannelInterfaceFactory = mock( LogChannelInterfaceFactory.class );
+        logChannelInterface = mock( LogChannelInterface.class );
+        KettleLogStore.setLogChannelInterfaceFactory( logChannelInterfaceFactory );
+        stepMeta = mock( StepMeta.class );
+        when( stepMeta.getName() ).thenReturn( stepName );
+        stepDataInterface = mock( stepDataClass );
+        transMeta = mock( TransMeta.class );
+        when( transMeta.findStep( stepName ) ).thenReturn( stepMeta );
+        trans = mock( Trans.class );
+        initStepMetaInterface = mock( stepMetaClass );
+        initStepDataInterface = mock( stepDataClass );
+        processRowsStepDataInterface = mock( stepDataClass );
+        processRowsStepMetaInterface = mock( stepMetaClass );
+    }
+
+    public RowSet getMockInputRowSet( Object[]... rows ) {
+        return getMockInputRowSet( asList( rows ) );
+    }
+
+    public RowSet getMockInputRowSet( final List<Object[]> rows ) {
+        final AtomicInteger index = new AtomicInteger( 0 );
+        RowSet rowSet = mock( RowSet.class, Mockito.RETURNS_MOCKS );
+        Answer<Object[]> answer = new Answer<Object[]>() {
+            @Override
+            public Object[] answer( InvocationOnMock invocation ) throws Throwable {
+                int i = index.getAndIncrement();
+                return i < rows.size() ? rows.get( i ) : null;
+            }
+        };
+        when( rowSet.getRowWait( anyLong(), any( TimeUnit.class ) ) ).thenAnswer( answer );
+        when( rowSet.getRow() ).thenAnswer( answer );
+        when( rowSet.isDone() ).thenAnswer( new Answer<Boolean>() {
+
+            @Override
+            public Boolean answer( InvocationOnMock invocation ) throws Throwable {
+                return index.get() >= rows.size();
+            }
+        } );
+        return rowSet;
+    }
+
+    public static List<Object[]> asList( Object[]... objects ) {
+        List<Object[]> result = new ArrayList<Object[]>();
+        Collections.addAll( result, objects );
+        return result;
+    }
+
+    public void cleanUp() {
+        KettleLogStore.setLogChannelInterfaceFactory( originalLogChannelInterfaceFactory );
+    }
+
+    /**
+     *  In case you need to use log methods during the tests
+     *  use redirectLog method after creating new StepMockHelper object.
+     *  Examples:
+     *    stepMockHelper.redirectLog( System.out, LogLevel.ROWLEVEL );
+     *    stepMockHelper.redirectLog( new FileOutputStream("log.txt"), LogLevel.BASIC );
+     */
+    public void redirectLog( final OutputStream out, LogLevel channelLogLevel ) {
+        final LogChannel log = spy( new LogChannel( this.getClass().getName(), true ) );
+        log.setLogLevel( channelLogLevel );
+        when( logChannelInterfaceFactory.create( any(), any( LoggingObjectInterface.class ) ) ).thenReturn( log );
+        doAnswer( new Answer<Object>() {
+            @Override
+            public Object answer( InvocationOnMock invocation ) throws Throwable {
+                Object[] args = invocation.getArguments();
+
+                LogLevel logLevel = (LogLevel) args[1];
+                LogLevel channelLogLevel = log.getLogLevel();
+
+                if ( !logLevel.isVisible( channelLogLevel ) ) {
+                    return null; // not for our eyes.
+                }
+                if ( channelLogLevel.getLevel() >= logLevel.getLevel() ) {
+                    LogMessageInterface logMessage = (LogMessageInterface) args[0];
+                    out.write( logMessage.getMessage().getBytes() );
+                    out.write( '\n' );
+                    out.write( '\r' );
+                    out.flush();
+                    return true;
+                }
+                return false;
+            }
+        } ).when( log ).println( (LogMessageInterface) anyObject(), (LogLevel) anyObject() );
+    }
+}

--- a/src/test/java/uk/gov/nationalarchives/pdi/step/jena/model/JenaModelStepIT.java
+++ b/src/test/java/uk/gov/nationalarchives/pdi/step/jena/model/JenaModelStepIT.java
@@ -1,0 +1,103 @@
+/**
+ * The MIT License
+ * Copyright © 2020 The National Archives
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package uk.gov.nationalarchives.pdi.step.jena.model;
+
+import javax.xml.namespace.QName;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.pentaho.di.core.KettleClientEnvironment;
+import org.pentaho.di.core.exception.KettleException;
+import org.pentaho.di.core.logging.LoggingObjectInterface;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.trans.steps.mock.StepMockHelper;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+public class JenaModelStepIT {
+    @BeforeAll
+    public static void setup() throws KettleException {
+        KettleClientEnvironment.init();
+    }
+
+    @Test
+    public void can_create_xsd_int_property() throws KettleException {
+        final JenaModelStepMeta meta = getMeta();
+        final StepMockHelper helper = mockHelper();
+        final JenaModelStep step = mockStep(helper);
+
+        final boolean rowProcessedSuccessfully = step.processRow(meta, helper.processRowsStepDataInterface);
+
+        assertTrue(rowProcessedSuccessfully);
+    }
+
+    private static JenaModelStepMeta getMeta() {
+        return new JenaModelStepMeta() {{
+            setDefault();
+            setTargetFieldName("targetField");
+            setResourceUriField("uriField");
+            setDbToJenaMappings(new DbToJenaMapping[]{
+                    new DbToJenaMapping() {{
+                        fieldName = "field1";
+                        rdfPropertyName = new QName("rdf:predicate");
+                        rdfType = new QName("xsd:int");
+                    }},
+            });
+        }};
+    }
+
+    private static StepMockHelper mockHelper() {
+        final StepMockHelper helper = new StepMockHelper<>("Create Jena Model", JenaModelStepMeta.class, JenaModelStepData.class);
+
+        when(helper.logChannelInterfaceFactory.create(any(), any(LoggingObjectInterface.class))).thenReturn(helper.logChannelInterface);
+        when(helper.trans.isRunning()).thenReturn(true);
+
+        return helper;
+    }
+
+    private static JenaModelStep mockStep(StepMockHelper helper) throws KettleException {
+        final JenaModelStep step = Mockito.spy(new JenaModelStep(helper.stepMeta, helper.stepDataInterface, 0, helper.transMeta, helper.trans));
+
+        final Object[] inputRowValues = {
+                0,
+                "http://example.com/resource"
+        };
+
+        final RowMeta inputRowSchema = new RowMeta() {{
+            addValueMeta(new ValueMetaInteger("field1"));
+            addValueMeta(new ValueMetaString("uriField"));
+        }};
+
+        doReturn(inputRowValues).when(step).getRow();
+        doReturn(inputRowSchema).when(step).getInputRowMeta();
+
+        return step;
+    }
+}


### PR DESCRIPTION
Very small change as a first PR, it's a step towards robust literal datatype support in the Jena Model Step as per #2.

Tested with a few combinations of sqlValue/datatype:
![image](https://user-images.githubusercontent.com/240741/105413004-643dfd80-5c2d-11eb-96ab-4e8c344f150e.png)

which produces acceptable RDF:
```turtle
@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
@prefix ex:      <http://example.com/> .
@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

ex:s  a       <> ;
      ex:bnde "1"^^xsd:decimal ;
      ex:bndo "1"^^xsd:double ;
      ex:bnf  "1"^^xsd:float ;
      ex:bnint "1"^^xsd:int ;
      ex:bninte 1 ;
      ex:bns  "1"^^xsd:short ;
      ex:ide  "1"^^xsd:decimal ;
      ex:ido  "1"^^xsd:double ;
      ex:if   "1"^^xsd:float ;
      ex:iint "1"^^xsd:int ;
      ex:iinte 1 ;
      ex:il   "1"^^xsd:long ;
      ex:is   "1"^^xsd:short ;
      ex:l    "1"^^xsd:long ;
      ex:nde  "1"^^xsd:decimal ;
      ex:ndo  "1.0"^^xsd:double ;
      ex:nf   "1.0"^^xsd:float ;
      ex:nint "1"^^xsd:int ;
      ex:ninte 1 ;
      ex:nl   "1"^^xsd:long ;
      ex:ns   "1"^^xsd:short .
```