### PR TITLE
Fix endless loop when 'Remove bNode' button is pressed

### DIFF
--- a/src/main/java/uk/gov/nationalarchives/pdi/step/jena/model/JenaModelStepDialog.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/jena/model/JenaModelStepDialog.java
@@ -831,8 +831,8 @@ public class JenaModelStepDialog extends BaseStepDialog implements StepDialogInt
                 final String[] rdfPropertyTypes = ciRdfPropertyTypes.getComboValues();
 
                 int removeIdx = -1;
-                for (i = 0; i < rdfPropertyTypes.length; i++) {
-                    final String rdfPropertyType = rdfPropertyTypes[i];
+                for (int j = 0; j < rdfPropertyTypes.length; j++) {
+                    final String rdfPropertyType = rdfPropertyTypes[j];
                     if (rdfPropertyType.equals(RESOURCE_DATA_TYPE)) {
                         break;
                     }
@@ -841,13 +841,13 @@ public class JenaModelStepDialog extends BaseStepDialog implements StepDialogInt
                     if (mtcBlankNodeId.matches()) {
                         final int bNodeId = Integer.parseInt(mtcBlankNodeId.group(1));
                         if (bNodeId == removedBNodeTabId) {
-                            removeIdx = i;
+                            removeIdx = j;
                         }
 
                         if (bNodeId > removedBNodeTabId) {
                             // decrement the entry
                             final int newBNodeId = bNodeId - 1;
-                            rdfPropertyTypes[i] = BLANK_NODE_NAME + ":" + newBNodeId;
+                            rdfPropertyTypes[j] = BLANK_NODE_NAME + ":" + newBNodeId;
                         }
                     }
                 }


### PR DESCRIPTION
The inner-loop reused the counter/guard of the outer-loop, which caused an endless flip-flop when the "Remove bNode" button was clicked.