### PR TITLE
Avoid warning when converting java.lang.Boolean to xsd:boolean

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <repository>
       <id>pentaho-nexus</id>
       <name>PentahoNexus</name>
-      <url>http://nexus.pentaho.org/content/groups/omni</url>
+      <url>https://nexus.pentaho.org/content/groups/omni</url>
     </repository>
   </repositories>
 

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/jena/model/JenaModelStep.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/jena/model/JenaModelStep.java
@@ -321,6 +321,12 @@ public class JenaModelStep extends BaseStep implements StepInterface {
 
             }
 
+        } else if (rdfDatatype.equals(XSDDatatype.XSDboolean)) {
+            // to xsd:boolean
+            if (sqlValue instanceof Boolean) {
+                return sqlValue;
+            }
+
         } else if (rdfDatatype.equals(XSDDatatype.XSDdate)) {
             // to xsd:date
             if (sqlValue instanceof String) {


### PR DESCRIPTION
If the property in the Jena Model is meant to be an `xsd:boolean` and the incoming field value is a `java.lang.Boolean`, then no conversion is needed.

This change causes an unnecessary warning that was shown when working with `xsd:boolean` fields to no longer be shown.