### PR TITLE
Add code-coverage via JaCoCo and Coveralls.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [1.8, 9, 11, 15]
+        jdk: [1.8, 9, 11, 15]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ matrix.java }}
+          java-version: ${{ matrix.jdk }}
       - name: Cache Maven packages
         uses: actions/cache@v2
         with:
@@ -32,4 +32,5 @@ jobs:
       - name: Maven Test
         run: mvn -B verify
       - name: Maven Code Coverage
+        if: ${{ matrix.jdk == '1.8' && matrix.os == 'ubuntu-latest' }}
         run: mvn -B jacoco:report coveralls:report -DrepoToken=${{ secrets.COVERALLS_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,6 @@ jobs:
       - name: Maven Build
         run: mvn -V -B -DskipTests=true install
       - name: Maven Test
-        run: mvn -V -B verify
+        run: mvn -B verify
+      - name: Maven Code Coverage
+        run: mvn -B jacoco:report coveralls:report -DrepoToken=${{ secrets.COVERALLS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/nationalarchives/kettle-jena-plugins/workflows/CI/badge.svg)](https://github.com/nationalarchives/kettle-jena-plugins/actions?query=workflow%3ACI)
 [![Java 8](https://img.shields.io/badge/java-8+-blue.svg)](https://adoptopenjdk.net/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Coverage Status](https://coveralls.io/repos/github/nationalarchives/kettle-jena-plugins/badge.svg?branch=main)](https://coveralls.io/github/nationalarchives/kettle-jena-plugins?branch=main)
 
 This project contains plugins for [Pentaho Data Integration](https://github.com/pentaho/pentaho-kettle) (or KETTLE as it is commonly known),
 that add functionality via [Apache Jena](https://jena.apache.org/) for producing RDF.

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
   <properties>
     <pentaho-kettle.version>8.3.0.9-719</pentaho-kettle.version>
     <pentaho-kettle.plugins.dir>C:\data-integration9.1\plugins</pentaho-kettle.plugins.dir>
-    <source.encoding>UTF-8</source.encoding>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.source.version>1.8</java.source.version>
     <java.target.version>1.8</java.target.version>
     <jena.version>3.16.0</jena.version>
@@ -183,7 +183,7 @@
         <artifactId>maven-resources-plugin</artifactId>
         <version>3.1.0</version>
         <configuration>
-          <encoding>${source.encoding}</encoding>
+          <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
       </plugin>
       <plugin>
@@ -212,7 +212,7 @@
             <!-- Ignore inconsistent (Apache) license for step mock helper class from Pentatho source https://github.com/pentaho/pentaho-kettle/blob/master/engine/src/test/java/org/pentaho/di/trans/steps/mock/StepMockHelper.java -->
             <exclude>src/test/java/org/pentaho/di/trans/steps/mock/StepMockHelper.java</exclude>
           </excludes>
-          <encoding>${source.encoding}</encoding>
+          <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
         <executions>
           <execution>
@@ -229,7 +229,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <encoding>${source.encoding}</encoding>
+          <encoding>${project.build.sourceEncoding}</encoding>
           <source>${java.source.version}</source>
           <target>${java.target.version}</target>
         </configuration>
@@ -314,7 +314,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.0.0-M5</version>
         <configuration>
-          <argLine>@{jacocoArgLine} -Dfile.encoding=${source.encoding}</argLine>
+          <argLine>@{jacocoArgLine} -Dfile.encoding=${project.build.sourceEncoding}</argLine>
         </configuration>
       </plugin>
       <plugin>
@@ -322,7 +322,7 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>3.0.0-M5</version>
         <configuration>
-          <argLine>@{jacocoArgLine} -Dfile.encoding=${source.encoding}</argLine>
+          <argLine>@{jacocoArgLine} -Dfile.encoding=${project.build.sourceEncoding}</argLine>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
 
   <name>Kettle Jena Plugins</name>
   <description>Apache Jena Plugins for Pentaho Data Integration (KETTLE) for producing RDF</description>
+  <url>https://github.com/nationalarchives/kettle-jena-plugins</url>
 
   <inceptionYear>2020</inceptionYear>
 
@@ -211,7 +212,7 @@
             <!-- Ignore inconsistent (Apache) license for step mock helper class from Pentatho source https://github.com/pentaho/pentaho-kettle/blob/master/engine/src/test/java/org/pentaho/di/trans/steps/mock/StepMockHelper.java -->
             <exclude>src/test/java/org/pentaho/di/trans/steps/mock/StepMockHelper.java</exclude>
           </excludes>
-          <encoding>${project.build.sourceEncoding}</encoding>
+          <encoding>${source.encoding}</encoding>
         </configuration>
         <executions>
           <execution>
@@ -294,9 +295,43 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.7</version>
+        <configuration>
+          <propertyName>jacocoArgLine</propertyName>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.0.0-M5</version>
+        <configuration>
+          <argLine>@{jacocoArgLine} -Dfile.encoding=${source.encoding}</argLine>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.0.0-M5</version>
+        <configuration>
+          <argLine>@{jacocoArgLine} -Dfile.encoding=${source.encoding}</argLine>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -319,21 +354,57 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <version>3.0.0-M5</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.9.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>3.1.2</version>
       </plugin>
     </plugins>
   </build>
 
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.7</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <!-- select non-aggregate reports -->
+              <report>report</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+    </plugins>
+  </reporting>
+
   <profiles>
+
+    <profile>
+      <id>upload-jacoco-to-coveralls</id>
+      <activation>
+        <!-- enabled in CI environment i.e. GitHub Actions -->
+        <property>
+          <name>env.CI</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eluder.coveralls</groupId>
+            <artifactId>coveralls-maven-plugin</artifactId>
+            <version>4.3.0</version>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>deploy-pdi-local</id>
       <build>
@@ -362,6 +433,6 @@
         </plugins>
       </build>
     </profile>
-  </profiles>
 
+  </profiles>
 </project>


### PR DESCRIPTION
It is expected that just the Ubuntu Java 1.8 build (which does the Coveralls.io upload) will fail with:
```
Failed to execute goal org.eluder.coveralls:coveralls-maven-plugin:4.3.0:report (default-cli) on project kettle-jena-plugins: Build error: Either repository token or service with job id must be defined
```
This is because this is a Pull Request and the repo secrets can't be accessed from there. After merge, it should run fine...