### PR TITLE
Only run Code-Coverage in CI against changes to the main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,5 +32,5 @@ jobs:
       - name: Maven Test
         run: mvn -B verify
       - name: Maven Code Coverage
-        if: ${{ matrix.jdk == '1.8' && matrix.os == 'ubuntu-latest' }}
+        if: ${{ github.ref == 'refs/heads/main' && matrix.jdk == '1.8' && matrix.os == 'ubuntu-latest' }}
         run: mvn -B jacoco:report coveralls:report -DrepoToken=${{ secrets.COVERALLS_TOKEN }}


### PR DESCRIPTION
The Coveralls Token is stored in the *secrets* of the GitHub repo and so is unavailable to PR (Pull Requests), therefore we should not even try to run coveralls code-coverage in a PR.