### PR TITLE
Fix QName parsing when there is only a local-name

### DIFF
--- a/src/main/java/uk/gov/nationalarchives/pdi/step/jena/Util.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/jena/Util.java
@@ -228,11 +228,16 @@ public class Util {
         } else {
             final int idxOpenBrace = qname.indexOf('{');
             final int idxCloseBrace = qname.indexOf('}');
-            if (idxOpenBrace != 0 || idxCloseBrace == qname.length() - 1 || idxCloseBrace < idxOpenBrace || (idxOpenBrace == -1 ^ idxCloseBrace == -1)) {
-                throw new IllegalArgumentException("Invalid qualified name: " + qname);
-            }
 
-            if (idxOpenBrace > -1 && idxCloseBrace > - 1) {
+            if (idxOpenBrace == -1 ^ idxCloseBrace == -1) {
+                throw new IllegalArgumentException("Invalid qualified name: " + qname);
+
+            } else if (idxOpenBrace > -1 && idxCloseBrace > - 1) {
+                if (idxOpenBrace != 0 || idxCloseBrace == qname.length() - 1 || idxCloseBrace < idxOpenBrace) {
+                    throw new IllegalArgumentException("Invalid qualified name: " + qname);
+                }
+
+
                 final String ns = qname.substring(idxOpenBrace + 1, idxCloseBrace);
                 final String localPart = qname.substring(idxCloseBrace + 1);
 

--- a/src/test/java/uk/gov/nationalarchives/pdi/step/UtilTest.java
+++ b/src/test/java/uk/gov/nationalarchives/pdi/step/UtilTest.java
@@ -160,6 +160,7 @@ public class UtilTest {
         assertEquals(new QName("ns", "local-name"),  Util.parseQName(null, "{ns}local-name"));
         assertEquals(new QName("ns", "local-name"),  Util.parseQName(Collections.emptyMap(), "{ns}local-name"));
         assertEquals(new QName("ns", "local-name"),  Util.parseQName(Map(Entry("prefix", "http://p1")), "{ns}local-name"));
+        assertEquals(new QName("local-part"), Util.parseQName(null, "local-part"));
     }
 
     @Test


### PR DESCRIPTION
Previously when refactoring to add additional tests for QName parsing, I broke an important use-case which was later revealed when using the plugin in a PDI transform. This fixes that by restoring the ability to parse just a local-name into a QName.