### PR TITLE
Allow RDF Property Names to also be specified by variable or field

### DIFF
--- a/src/main/java/uk/gov/nationalarchives/pdi/step/jena/Util.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/jena/Util.java
@@ -27,6 +27,7 @@ import uk.gov.nationalarchives.pdi.step.jena.model.JenaModelStepMeta;
 
 import javax.annotation.Nullable;
 import javax.xml.namespace.QName;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -263,5 +264,48 @@ public class Util {
             return null;
         }
         return new QName(qname.getNamespaceURI(), qname.getLocalPart(), qname.getPrefix());
+    }
+
+    /**
+     * Simple fluent API for constructing a Map.
+     *
+     * @param entries the entries for the map
+     * @param <K> the type of the keys in the map
+     * @param <V> the type of the values in the map
+     *
+     * @return The Map
+     */
+    public static <K, V> Map<K,V> Map(final Entry<K, V>... entries) {
+        final Map<K, V> map = new HashMap<>();
+        if (entries != null) {
+            for (final Entry<K, V> entry : entries) {
+                map.put(entry.key, entry.value);
+            }
+        }
+        return map;
+    }
+
+    /**
+     * Simple fluent API for constructing an entry for a Map.
+     *
+     * @param key the key for the entry
+     * @param value the value for the entry
+     * @param <K> the type of the keys in the map
+     * @param <V> the type of the values in the map
+     *
+     * @return The Map entry
+     */
+    public static <K, V> Entry<K,V> Entry(final K key, final V value) {
+        return new Entry(key, value);
+    }
+
+    public static class Entry<K, V> {
+        final K key;
+        final V value;
+
+        private Entry(final K key, final V value) {
+            this.key = key;
+            this.value = value;
+        }
     }
 }

--- a/src/main/java/uk/gov/nationalarchives/pdi/step/jena/model/JenaModelStepDialog.java
+++ b/src/main/java/uk/gov/nationalarchives/pdi/step/jena/model/JenaModelStepDialog.java
@@ -489,7 +489,7 @@ public class JenaModelStepDialog extends BaseStepDialog implements StepDialogInt
             for (final JenaModelStepMeta.DbToJenaMapping dbToJenaMapping : dbToJenaMappings) {
                 tableView.add(new String[] {
                         dbToJenaMapping.fieldName,
-                        Util.asPrefixString(dbToJenaMapping.rdfPropertyName),
+                        dbToJenaMapping.rdfPropertyNameSource.toString(),
                         Util.asPrefixString(dbToJenaMapping.rdfType),
                         dbToJenaMapping.skip ?
                                 BaseMessages.getString(PKG, "JenaModelStepDialog.SkipYes") :
@@ -955,7 +955,7 @@ public class JenaModelStepDialog extends BaseStepDialog implements StepDialogInt
             final JenaModelStepMeta.DbToJenaMapping dbToJenaMapping = new JenaModelStepMeta.DbToJenaMapping();
             dbToJenaMapping.fieldName = fieldName;
             final String propertyName = tableView.getItem(i, 2);
-            dbToJenaMapping.rdfPropertyName = Util.parseQName(namespaces, propertyName);
+            dbToJenaMapping.rdfPropertyNameSource = JenaModelStepMeta.RdfPropertyNameSource.fromString(namespaces, propertyName);
             final String rdfType = Util.nullIfEmpty(tableView.getItem(i, 3));
             dbToJenaMapping.rdfType = Util.parseQName(namespaces, rdfType);
             dbToJenaMapping.skip = tableView.getItem(i, 4).equals(BaseMessages.getString(PKG, "JenaModelStepDialog.SkipYes"));

--- a/src/test/java/uk/gov/nationalarchives/pdi/step/UtilTest.java
+++ b/src/test/java/uk/gov/nationalarchives/pdi/step/UtilTest.java
@@ -29,6 +29,8 @@ import javax.xml.namespace.QName;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static uk.gov.nationalarchives.pdi.step.jena.Util.Entry;
+import static uk.gov.nationalarchives.pdi.step.jena.Util.Map;
 
 public class UtilTest {
 
@@ -172,27 +174,26 @@ public class UtilTest {
         assertEquals(new QName("ns", "local-part", "prefix"), new QName("ns", "local-part", "prefix"));
     }
 
-    private static <K, V> Map<K,V> Map(final Entry<K, V>... entries) {
-        final Map<K, V> map = new HashMap<>();
-        if (entries != null) {
-            for (final Entry<K, V> entry : entries) {
-                map.put(entry.key, entry.value);
-            }
-        }
-        return map;
+    @Test
+    public void map() {
+        assertEquals(Collections.emptyMap(), Map(null));
+        assertEquals(Collections.emptyMap(), Map());
+
+        final Map<String, String> expected1 = new HashMap<>();
+        expected1.put("k1", "v1");
+        assertEquals(expected1, Map(Entry("k1", "v1")));
+
+        final Map<String, String> expected2 = new HashMap<>();
+        expected2.put("k1", "v1");
+        expected2.put("k2", "v2");
+        expected2.put("k3", "v3");
+        assertEquals(expected2, Map(Entry("k1", "v1"), Entry("k2", "v2"), Entry("k3", "v3")));
+
+        final Map<Integer, Float> expected3 = new HashMap<>();
+        expected3.put(1, 0.1f);
+        expected3.put(2, 0.2f);
+        expected3.put(3, 0.3f);
+        assertEquals(expected3, Map(Entry(1, 0.1f), Entry(2, 0.2f), Entry(3, 0.3f)));
     }
 
-    private static <K, V> Entry<K,V> Entry(final K key, final V value) {
-        return new Entry(key, value);
-    }
-
-    private static class Entry<K, V> {
-        final K key;
-        final V value;
-
-        private Entry(final K key, final V value) {
-            this.key = key;
-            this.value = value;
-        }
-    }
 }

--- a/src/test/java/uk/gov/nationalarchives/pdi/step/jena/model/JenaModelStepIT.java
+++ b/src/test/java/uk/gov/nationalarchives/pdi/step/jena/model/JenaModelStepIT.java
@@ -22,6 +22,7 @@
  */
 package uk.gov.nationalarchives.pdi.step.jena.model;
 
+import org.apache.jena.vocabulary.RDF;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -35,6 +36,7 @@ import org.pentaho.di.core.row.value.ValueMetaInteger;
 import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.trans.step.RowHandler;
 import org.pentaho.di.trans.steps.mock.StepMockHelper;
+import uk.gov.nationalarchives.pdi.step.jena.Rdf11;
 
 import javax.xml.namespace.QName;
 
@@ -42,6 +44,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static uk.gov.nationalarchives.pdi.step.jena.Util.Entry;
+import static uk.gov.nationalarchives.pdi.step.jena.Util.Map;
 
 public class JenaModelStepIT {
     @BeforeAll
@@ -102,7 +106,7 @@ public class JenaModelStepIT {
 
         final JenaModelStepMeta.DbToJenaMapping mapping = new JenaModelStepMeta.DbToJenaMapping();
         mapping.fieldName = "field1";
-        mapping.rdfPropertyName = new QName("rdf:predicate");
+        mapping.rdfPropertyNameSource = JenaModelStepMeta.RdfPropertyNameSource.fromString(Map(Entry(Rdf11.RDF_PREFIX, RDF.uri)), "rdf:predicate");
         mapping.rdfType = new QName("xsd:int");
 
         meta.setDbToJenaMappings(new JenaModelStepMeta.DbToJenaMapping[]{

--- a/src/test/java/uk/gov/nationalarchives/pdi/step/jena/model/RdfPropertyNameSourceTest.java
+++ b/src/test/java/uk/gov/nationalarchives/pdi/step/jena/model/RdfPropertyNameSourceTest.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License
+ * Copyright © 2020 The National Archives
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package uk.gov.nationalarchives.pdi.step.jena.model;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.nationalarchives.pdi.step.jena.model.JenaModelStepMeta.RdfPropertyNameSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static uk.gov.nationalarchives.pdi.step.jena.Util.Entry;
+import static uk.gov.nationalarchives.pdi.step.jena.Util.Map;
+
+public class RdfPropertyNameSourceTest {
+
+    @Test
+    public void fromString() {
+        assertNull(RdfPropertyNameSource.fromString(null, null));
+        assertNull(RdfPropertyNameSource.fromString(null, ""));
+
+        RdfPropertyNameSource source = RdfPropertyNameSource.fromString(null, "local-part");
+        assertTrue(source instanceof JenaModelStepMeta.RdfPropertyNameLiteralSource);
+        assertEquals(JenaModelStepMeta.SourceType.LITERAL, source.getSourceType());
+        assertEquals("local-part", source.toString());
+
+        source = RdfPropertyNameSource.fromString(Map(Entry("ns", "http://ns")), "ns:local-part");
+        assertTrue(source instanceof JenaModelStepMeta.RdfPropertyNameLiteralSource);
+        assertEquals(JenaModelStepMeta.SourceType.LITERAL, source.getSourceType());
+        assertEquals("ns:local-part", source.toString());
+
+        source = RdfPropertyNameSource.fromString(null, "#{field1}");
+        assertTrue(source instanceof JenaModelStepMeta.RdfPropertyNameFieldSource);
+        assertEquals(JenaModelStepMeta.SourceType.FIELD, source.getSourceType());
+        assertEquals("#{field1}", source.toString());
+        assertEquals("field1", ((JenaModelStepMeta.RdfPropertyNameFieldSource)source).getFieldName());
+
+        source = RdfPropertyNameSource.fromString(null, "${var1}");
+        assertTrue(source instanceof JenaModelStepMeta.RdfPropertyNameVariableSource);
+        assertEquals(JenaModelStepMeta.SourceType.VARIABLE, source.getSourceType());
+        assertEquals("${var1}", source.toString());
+        assertEquals("var1", ((JenaModelStepMeta.RdfPropertyNameVariableSource)source).getVariableName());
+    }
+}


### PR DESCRIPTION
Previously when mapping fields to RDF Property Names, the RDF Property Name could only be a literal QName. This change allows them to also be sourced from a field in the input row or a variable.

For variables the PDI `${variableName}` syntax is used. For fields the syntax `#{fieldName}` may be used.